### PR TITLE
#159249662 Replace 'req' and 'res' with 'request' and 'response' respectively

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
         { "caseSensitive": false }, 
         { "commonjs": true }
       ],
-      "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
+      "no-shadow": ["error", { "allow": ["request", "response", "err"] }],
       "valid-jsdoc": ["error", {
         "requireReturn": true,
         "requireReturnType": true,

--- a/server/app.js
+++ b/server/app.js
@@ -15,7 +15,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 app.use('/api/v1/entries', entry);
 
-app.get('*', (req, res) => res.status(200).send({
+app.get('*', (request, response) => response.status(200).send({
   message: 'Welcome To myDiary API!!!',
 }));
 

--- a/server/controllers/entries.js
+++ b/server/controllers/entries.js
@@ -12,16 +12,16 @@ const entry = data;
 class Entry {
   /**
    *@description - Fetch all entries
-  *@param {object} req - request object
+  *@param {object} request - request object
    *
-   * @param {object} res - responce object
+   * @param {object} response - responce object
    *
    * @return {object} return object as response
    *
    * @memberof Entry
    * */
-  static getAll(req, res) {
-    return res.status(200).send({
+  static getAll(request, response) {
+    return response.status(200).send({
       message: 'Successful',
       entry: data,
       error: false
@@ -29,25 +29,25 @@ class Entry {
   }
   /**
  *@description - Fetch one entry
- *@param {object} req - request object
+ *@param {object} request - request object
  *
- * @param {object} res - responce object
+ * @param {object} response - responce object
  *
  * @return {object} return object as response
  *
  * @memberof Entry
 */
-  static getOne(req, res) {
+  static getOne(request, response) {
     for (let i = 0; i < entry.length; i++) {
-      if (entry[i].entryId === parseInt(req.params.entryId, 10)) {
-        return res.send({
+      if (entry[i].entryId === parseInt(request.params.entryId, 10)) {
+        return response.send({
           message: 'Successful',
           entry: data[i],
           error: false
         });
       }
     }
-    return res.status(404).send({
+    return response.status(404).send({
       message: 'Entry not found!',
       error: true
     });
@@ -63,17 +63,17 @@ class Entry {
 *
 * @memberof Entry
 */
-  static createEntry(req, res) {
+  static createEntry(request, response) {
     const {
       title, mood, entry, date
-    } = req.body;
+    } = request.body;
 
     const entryId = data.length + 1;
 
     data.push({
       entryId, userId: 1, title, mood, entry, date
     });
-    return res.status(201).send({
+    return response.status(201).send({
       message: 'Entry Created Successfully',
       entry: data,
       error: false
@@ -82,29 +82,29 @@ class Entry {
   /**
    *@description - Modify details of an entry
    *
-   *@param {object} req - HTTP request
+   *@param {object} request - HTTP request
    *
-   * @param {object} res
+   * @param {object} response
    *
    * @return {object} this - Class instance
    *
    * @memberof Entry
    */
-  static modifyEntry(req, res) {
+  static modifyEntry(request, response) {
     for (let i = 0; i < entry.length; i++) {
-      if (entry[i].entryId === parseInt(req.params.entryId, 10)) {
-        entry[i].title = req.body.title;
-        entry[i].mood = req.body.mood;
-        entry[i].entry = req.body.entry;
-        entry[i].date = req.body.date;
-        return res.send({
+      if (entry[i].entryId === parseInt(request.params.entryId, 10)) {
+        entry[i].title = request.body.title;
+        entry[i].mood = request.body.mood;
+        entry[i].entry = request.body.entry;
+        entry[i].date = request.body.date;
+        return response.send({
           message: 'Update Successful',
           entry: data[i],
           error: false
         });
       }
     }
-    return res.status(404).send({
+    return response.status(404).send({
       message: 'Entry not found',
       error: true
     });

--- a/server/middlewares/validate.js
+++ b/server/middlewares/validate.js
@@ -7,9 +7,9 @@ import Validator from 'validatorjs';
 class Validate {
   /**
    *
-   * @param {request} req
+   * @param {request} request
    *
-   * @param {response} res
+   * @param {response} response
    *
    * @param {function} next
    *
@@ -17,11 +17,11 @@ class Validate {
    *
    * @memberof Validate
    */
-  static entryId(req, res, next) {
-    const { entryId } = req.params;
+  static entryId(request, response, next) {
+    const { entryId } = request.params;
 
     if (isNaN(entryId)) {
-      return res.status(400).json({
+      return response.status(400).json({
         message: 'Parameter must be a number!'
       });
     }
@@ -29,9 +29,9 @@ class Validate {
   }
   /**
    *
-   * @param {object} req
+   * @param {object} request
    *
-   * @param {object} res
+   * @param {object} response
    *
    * @param {unctionf} next
    *
@@ -39,8 +39,8 @@ class Validate {
    *
    * @memberof Validate
   */
-  static createEntry(req, res, next) {
-    const { title, mood, entry } = req.body;
+  static createEntry(request, response, next) {
+    const { title, mood, entry } = request.body;
 
     const entryData = { title, mood, entry };
 
@@ -55,15 +55,15 @@ class Validate {
       next();
     } else {
       const errors = validation.errors.all();
-      return res.status(400)
+      return response.status(400)
         .json({ message: errors });
     }
   }
     /**
    *
-   * @param {object} req
+   * @param {object} request
    *
-   * @param {object} res
+   * @param {object} response
    *
    * @param {unctionf} next
    *
@@ -71,8 +71,8 @@ class Validate {
    *
    * @memberof Validate
   */
- static modifyEntry(req, res, next) {
-  const { title, mood, entry } = req.body;
+ static modifyEntry(request, response, next) {
+  const { title, mood, entry } = request.body;
 
   const entryData = { title, mood, entry};
 
@@ -87,7 +87,7 @@ class Validate {
     next();
   } else {
     const errors = validation.errors.all();
-    return res.status(400)
+    return response.status(400)
       .json({ message: errors });
   }
 }

--- a/server/tests/entry.tests.js
+++ b/server/tests/entry.tests.js
@@ -15,10 +15,10 @@ describe('API Integration Tests', () => {
       chai.request(app)
         .get('/api/v1/entries')
         .send()
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.should.be.a('object'));
-          expect(res.body.message).to.equal('Successful')
+        .end((err, response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body.should.be.a('object'));
+          expect(response.body.message).to.equal('Successful')
           done();
         });
     });
@@ -28,10 +28,10 @@ describe('API Integration Tests', () => {
       chai.request(app)
         .get('/api/v1/entries/1')
         .send()
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.should.be.a('object'));
-          expect(res.body.message).to.equal('Successful')
+        .end((err, response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body.should.be.a('object'));
+          expect(response.body.message).to.equal('Successful')
           done();
         });
     });
@@ -39,9 +39,9 @@ describe('API Integration Tests', () => {
       chai.request(app)
         .get('/api/v1/entries/6')
         .send()
-        .end((err, res) => {
-          expect(res.status).to.equal(404);
-          expect(res.body.message).to.equal('Entry not found!')
+        .end((err, response) => {
+          expect(response.status).to.equal(404);
+          expect(response.body.message).to.equal('Entry not found!')
           done();
         });
     });
@@ -57,10 +57,10 @@ describe('API Integration Tests', () => {
           entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
           date: '11/01/2018'
         })
-        .end((err, res) => {
-          expect(res.status).to.equal(201);
-          expect(res.body.should.be.a('object'));
-          expect(res.body.message).to.equal('Entry Created Successfully')
+        .end((err, response) => {
+          expect(response.status).to.equal(201);
+          expect(response.body.should.be.a('object'));
+          expect(response.body.message).to.equal('Entry Created Successfully')
           done();
         });
     });
@@ -75,15 +75,15 @@ describe('API Integration Tests', () => {
         entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
         date: '11/01/2018'
       })
-      .end((err, res) => {
+      .end((err, response) => {
         const message = {
           title: [
             'The title field is required.'
           ]
         };
-        expect(res.status).to.equal(400);
-        expect(res.body.should.be.a('object'));
-        expect(res.body).to.haveOwnProperty('message').to.eql(message);
+        expect(response.status).to.equal(400);
+        expect(response.body.should.be.a('object'));
+        expect(response.body).to.haveOwnProperty('message').to.eql(message);
         done();
       });
   });
@@ -97,15 +97,15 @@ describe('API Integration Tests', () => {
         entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
         date: '11/01/2018'
       })
-      .end((err, res) => {
+      .end((err, response) => {
         const message = {
           mood: [
             'The mood field is required.'
           ]
         };
-        expect(res.status).to.equal(400);
-        expect(res.body.should.be.a('object'));
-        expect(res.body).to.haveOwnProperty('message').to.eql(message);
+        expect(response.status).to.equal(400);
+        expect(response.body.should.be.a('object'));
+        expect(response.body).to.haveOwnProperty('message').to.eql(message);
         done();
       });
   });
@@ -120,15 +120,15 @@ describe('API Integration Tests', () => {
         mood: 'Happy',
         date: '11/01/2018'
       })
-      .end((err, res) => {
+      .end((err, response) => {
         const message = {
           entry: [
             'The entry field is required.'
           ]
         };
-        expect(res.status).to.equal(400);
-        expect(res.body.should.be.a('object'));
-        expect(res.body).to.haveOwnProperty('message').to.eql(message);
+        expect(response.status).to.equal(400);
+        expect(response.body.should.be.a('object'));
+        expect(response.body).to.haveOwnProperty('message').to.eql(message);
         done();
       });
   });
@@ -145,10 +145,10 @@ describe('API Integration Tests', () => {
           Entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
           date: '11/01/2018'
         })
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body.should.be.a('object'));
-        expect(res.body).to.haveOwnProperty('message').to.eql('Update Successful');
+        .end((err, response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body.should.be.a('object'));
+        expect(response.body).to.haveOwnProperty('message').to.eql('Update Successful');
           done();
         });
     });
@@ -157,10 +157,10 @@ describe('API Integration Tests', () => {
       chai.request(app)
         .put('/api/v1/entries/6')
         .send()
-        .end((err, res) => {
+        .end((err, response) => {
           const message = 'Entry not found';
-          expect(res.status).to.equal(404);
-          expect(res.body).to.haveOwnProperty('message').to.eql(message);
+          expect(response.status).to.equal(404);
+          expect(response.body).to.haveOwnProperty('message').to.eql(message);
           done();
         });
     });
@@ -168,10 +168,10 @@ describe('API Integration Tests', () => {
       chai.request(app)
       .put('/api/v1/entries/okkkk')
       .send()
-      .end((err, res) => {
+      .end((err, response) => {
         const message = 'Parameter must be a number!';
-        expect(res.status).to.equal(400);
-        expect(res.body).to.haveOwnProperty('message').to.eql(message);
+        expect(response.status).to.equal(400);
+        expect(response.body).to.haveOwnProperty('message').to.eql(message);
         done();
       });
     });
@@ -185,9 +185,9 @@ describe('API Integration Tests', () => {
           entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
           date: '11/01/2018'
         })
-        .end((err, res) => {
-          expect(res.status).to.equal(400);
-          expect(res.body.should.be.a('object'));
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          expect(response.body.should.be.a('object'));
           done();
         });
     });
@@ -201,9 +201,9 @@ describe('API Integration Tests', () => {
           entry: 'Set in the former city archive of Cologne, this design hotel is the perfect place to immerse yourself in the history of the city while enjoying a luxurious experience. The suites are to-die-for, and its location in a quiet but central neighborhood puts you right in the middle of the action in minutes.',
           date: '11/01/2018'
         })
-        .end((err, res) => {
-          expect(res.status).to.equal(400);
-          expect(res.body.should.be.a('object'));
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          expect(response.body.should.be.a('object'));
           done();
         });
     });
@@ -217,9 +217,9 @@ describe('API Integration Tests', () => {
           entry: 456987,
           date: '11/01/2018'
         })
-        .end((err, res) => {
-          expect(res.status).to.equal(400);
-          expect(res.body.should.be.a('object'));
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          expect(response.body.should.be.a('object'));
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
Replaces the abbreviated 'req' and 'res' keyword with with the full word 'request' and 'response'
#### Description of Task to be completed?
N/A
#### How should this be manually tested?
N/A
#### Any background context you want to provide?
The abbreviated form was used previously
#### What are the relevant pivotal tracker stories?
#159249662 - replace 'req' and 'res' with 'request' and 'response' respectively
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A